### PR TITLE
add: オンラインソース選択ルートに利用するページヘルパーを実装

### DIFF
--- a/e2e/test/equinox/pages/breathing_method_add.clj
+++ b/e2e/test/equinox/pages/breathing_method_add.clj
@@ -1,0 +1,34 @@
+(ns equinox.pages.breathing-method-add
+  (:require [etaoin.api :as e]))
+
+(def selectors
+  {:inhale-input [{:tag "input" :aria-label "inhale-duration-input"}]
+   :inhale-hold-input [{:tag "input" :aria-label "inhale-hold-duration-input"}]
+   :exhale-input [{:tag "input" :aria-label "exhale-duration-input"}]
+   :exhale-hold-input [{:tag "input" :aria-label "exhale-hold-duration-input"}]
+
+   :name-input [{:tag "input" :aria-label "breathing-method-name-input"}]
+   :category-combobox [{:role "combobox" :aria-label "category-combobox"}]
+
+   :submit-breathing-method-button [{:tag "button" :aria-label "submit-breathing-method"}]})
+
+(defn set-custom-breathing-parameters
+  [driver {:keys [inhale inhale-hold exhale exhale-hold]}]
+  (e/fill driver (:inhale-input selectors) (str inhale))
+  (e/fill driver (:inhale-hold-input selectors) (str inhale-hold))
+  (e/fill driver (:exhale-input selectors) (str exhale))
+  (e/fill driver (:exhale-hold-input selectors) (str exhale-hold)))
+
+(defn set-breathing-name [driver name]
+  (e/fill driver (:name-input selectors) name))
+
+;; ここはわからない。
+(defn select-category [driver category]
+  (e/select driver (:category-combobox selectors) category))
+
+;; ここも実装が必要。comboboxの最低限の実装が終わってからわかる。
+(defn create-category [driver catgory-title]
+  (comment `(todo implement)))
+
+(defn submit-breathing-method [driver]
+  (e/click driver (:submit-breathing-method-button selectors)))

--- a/e2e/test/equinox/pages/source_selection.clj
+++ b/e2e/test/equinox/pages/source_selection.clj
@@ -1,0 +1,18 @@
+(ns equinox.pages.source-selection
+  (:require [etaoin.api :as e]))
+
+(def selectors
+  {;; オンラインソース選択
+   :online-source-selection-button [{:tag "button" :aria-label "online-source-selection-button"}]
+   :online-list [{:tag "ul" :aria-label "online-list"}]
+   :online-item [{:tag "button" :aria-label "online-item"}]})
+
+;; オンラインソース選択ルート
+
+(defn click-online-source-selection-button
+  [driver]
+  (e/click driver (:online-source-selection-button selectors)))
+
+(defn click-online-item
+  [driver]
+  (e/click driver (:online-item selectors)))


### PR DESCRIPTION
オンラインソース選択に利用するページヘルパーを実装した。オンラインのアイテムを選択するsource_selection、新規でBreathingMethodを追加するbreathing_method_addを追加。