### PR TITLE
update: UUID生成を複数のTEAコンポーネントから呼び出せるように修正

### DIFF
--- a/frontend/src/JS/Ports.elm
+++ b/frontend/src/JS/Ports.elm
@@ -160,23 +160,26 @@ saveSessionValue session =
 
 {-| UUID生成のリクエストを送信します。
 -}
-port generateUuid : () -> Cmd msg
+port generateUuid : String -> Cmd msg
 
 
 {-| UUID生成のリクエストを送信するCmdを生成するラッパーです。
+
+UUIDを生成した後に、どちらに登録されているコールバックを実行すればいいだけである。
+
 -}
-generateUuidValue : Cmd msg
-generateUuidValue =
-    generateUuid ()
+generateUuidValue : String -> Cmd msg
+generateUuidValue tag =
+    generateUuid tag
 
 
 {-| UUID生成の結果を受け取るポートです。
 -}
-port receiveUuid : (String -> msg) -> Sub msg
+port receiveUuid : (( String, String ) -> msg) -> Sub msg
 
 
 {-| UUID生成の結果を受け取るSubを生成するラッパーです。
 -}
-subscribeToUuid : (String -> msg) -> Sub msg
+subscribeToUuid : (( String, String ) -> msg) -> Sub msg
 subscribeToUuid toMsg =
     receiveUuid toMsg

--- a/frontend/src/typescript/uuid.ts
+++ b/frontend/src/typescript/uuid.ts
@@ -2,8 +2,8 @@ import { v4 } from "uuid";
 import { Elm } from "../Main.elm";
 
 export const applyUuid = (elm: Elm.Main.App): Elm.Main.App => {
-  elm.ports.generateUuid.subscribe(() => {
-    elm.ports.receiveUuid.send(v4());
+  elm.ports.generateUuid.subscribe((tag) => {
+    elm.ports.receiveUuid.send([tag, v4()]);
   });
   return elm;
 };


### PR DESCRIPTION
UUID生成のシステムを更新した。以前はMain.elmからしかUUIDを生成できず、また子コンポーネント内では生成が難しかった。それはMain.elmのsubscriptionsによってすべての生成されたUUIDのメッセージが吸収されてしまうからだったが、タグ付きコールバックをMain.elmに登録し、子コンポーネントでもそのレジストリを更新するようにしたことで、子コンポーネントにメッセージを送ることができるようになった。