### PR TITLE
change: Main.elmにあるリダイレクト処理をページ内に移動

### DIFF
--- a/frontend/review/src/NoMainReplaceUrl.elm
+++ b/frontend/review/src/NoMainReplaceUrl.elm
@@ -1,0 +1,108 @@
+module NoMainReplaceUrl exposing (rule)
+
+import Elm.Syntax.Expression as Expression exposing (Expression)
+import Elm.Syntax.Import exposing (Import)
+import Elm.Syntax.Node as Node exposing (Node)
+import Elm.Syntax.Exposing as Exposing
+import Review.Rule as Rule exposing (Rule)
+
+type alias Context =
+    { replaceUrlInScope : Bool
+    , navigationModules : List (List String)
+    }
+
+rule : Rule
+rule =
+    Rule.newModuleRuleSchema "NoMainReplaceUrl" initialContext
+        |> Rule.withImportVisitor importVisitor
+        |> Rule.withExpressionEnterVisitor expressionVisitor
+        |> Rule.fromModuleRuleSchema
+        |> Rule.filterErrorsForFiles (\path -> path == "src/Main.elm")
+
+initialContext : Context
+initialContext =
+    { replaceUrlInScope = False
+    , navigationModules = [ [ "Browser", "Navigation" ] ]
+    }
+
+importVisitor : Node Import -> Context -> ( List (Rule.Error {}), Context )
+importVisitor node context =
+    let
+        import_ : Import
+        import_ =
+            Node.value node
+
+        moduleName : List String
+        moduleName =
+            Node.value import_.moduleName
+
+        isNavigationImport : Bool
+        isNavigationImport =
+            List.member moduleName context.navigationModules
+
+        checkExposing : Exposing.Exposing -> Bool
+        checkExposing exposing_ =
+            case exposing_ of
+                Exposing.All _ ->
+                    True
+
+                Exposing.Explicit exposedList ->
+                    List.any
+                        (\exposed ->
+                            case Node.value exposed of
+                                Exposing.FunctionExpose name ->
+                                    name == "replaceUrl"
+
+                                _ ->
+                                    False
+                        )
+                        exposedList
+
+        hasReplaceUrlExposed : Bool
+        hasReplaceUrlExposed =
+            import_.exposingList
+                |> Maybe.map Node.value
+                |> Maybe.map checkExposing
+                |> Maybe.withDefault False
+
+        aliasModules : List (List String)
+        aliasModules =
+            import_.moduleAlias
+                |> Maybe.map Node.value
+                |> Maybe.map List.singleton
+                |> Maybe.withDefault []
+    in
+    if isNavigationImport then
+        ( []
+        , { context
+            | replaceUrlInScope = context.replaceUrlInScope || hasReplaceUrlExposed
+            , navigationModules = aliasModules ++ context.navigationModules
+          }
+        )
+    else
+        ( [], context )
+
+expressionVisitor : Node Expression -> Context -> ( List (Rule.Error {}), Context )
+expressionVisitor node context =
+    case Node.value node of
+        Expression.FunctionOrValue moduleName "replaceUrl" ->
+            if moduleName == [] && context.replaceUrlInScope then
+                ( [ error node ], context )
+            else if List.member moduleName context.navigationModules then
+                ( [ error node ], context )
+            else
+                ( [], context )
+
+        _ ->
+            ( [], context )
+
+error : Node Expression -> Rule.Error {}
+error node =
+    Rule.error
+        { message = "Do not use Browser.Navigation.replaceUrl in Main.elm"
+        , details =
+            [ "画面表示不正による画面リダイレクトを行う処理は Page/ 配下のモジュールで実装してください。"
+            , "Main モジュールでの Browser.Navigation の直接使用は避け、適切なページモジュールに遷移ロジックを移動してください。"
+            ]
+        }
+        (Node.range node)

--- a/frontend/review/src/ReviewConfig.elm
+++ b/frontend/review/src/ReviewConfig.elm
@@ -13,9 +13,11 @@ when inside the directory containing this file.
 
 import Review.Rule exposing (Rule)
 import DocumentationRule
+import NoMainReplaceUrl
 
 
 config : List Rule
 config =
     [ DocumentationRule.rule
+    , NoMainReplaceUrl.rule
     ]

--- a/frontend/src/Pages/SessionCompletionPage.elm
+++ b/frontend/src/Pages/SessionCompletionPage.elm
@@ -2,6 +2,7 @@ module Pages.SessionCompletionPage exposing
     ( Msg
     , view
     , update
+    , Model, init
     )
 
 {-|
@@ -32,8 +33,12 @@ import Browser.Navigation as Nav
 import Html exposing (Html, button, div, span, text)
 import Html.Attributes exposing (attribute, value)
 import Html.Events exposing (onClick)
+import Pages.SessionPreparationPage exposing (PracticeStyle(..))
 import Route exposing (Route(..))
+import Task
+import Time
 import Types.Session exposing (Duration, fromDuration)
+import Uuid
 
 
 {-| メッセージ
@@ -42,34 +47,87 @@ type Msg
     = NavigateToRoute Route
 
 
+{-| Model
+-}
+type Model
+    = ModelInvalid PracticeStyle
+    | ModelValid
+        { duration : Duration
+        , practiceStyle : PracticeStyle
+        }
+
+
+{-| 初期化
+-}
+init : Maybe Duration -> PracticeStyle -> ( Model, Cmd Msg )
+init mduration practiceStyle =
+    case mduration of
+        Just duration ->
+            ( ModelValid
+                { duration = duration
+                , practiceStyle = practiceStyle
+                }
+            , Cmd.none
+            )
+
+        Nothing ->
+            ( ModelInvalid practiceStyle
+            , (case practiceStyle of
+                PresetPracticeStyle id ->
+                    PresetSessionPreparationRoute id
+
+                ManualPracticeStyle ->
+                    ManualSessionPreparationRoute
+              )
+                |> NavigateToRoute
+                |> always
+                |> Task.perform
+                |> (|>) Time.now
+            )
+
+
 {-| ビュー
 -}
-view : { a | duration : Duration, txt : String } -> Html Msg
-view { duration, txt } =
-    div [ attribute "role" "session-completion" ]
-        [ text txt
-        , text "完了"
-        , span
-            [ attribute "aria-label" "finish-duration"
-            , value (String.fromInt <| fromDuration duration)
-            ]
-            [ text <| (String.fromInt << fromDuration) duration ]
-        , text "秒"
-        , button
-            [ attribute "aria-label" "next" ]
-            [ text "次へ" ]
-        , button
-            [ attribute "aria-label" "finish"
-            , onClick (NavigateToRoute StatisticsRoute)
-            ]
-            [ text "完了" ]
-        ]
+view : Model -> Html Msg
+view model =
+    case model of
+        ModelValid { duration, practiceStyle } ->
+            let
+                txt =
+                    case practiceStyle of
+                        PresetPracticeStyle id ->
+                            "完了画面 - ID: " ++ Uuid.toString id
+
+                        ManualPracticeStyle ->
+                            "カスタム完了画面"
+            in
+            div [ attribute "role" "session-completion" ]
+                [ text txt
+                , text "完了"
+                , span
+                    [ attribute "aria-label" "finish-duration"
+                    , value (String.fromInt <| fromDuration duration)
+                    ]
+                    [ text <| (String.fromInt << fromDuration) duration ]
+                , text "秒"
+                , button
+                    [ attribute "aria-label" "next" ]
+                    [ text "次へ" ]
+                , button
+                    [ attribute "aria-label" "finish"
+                    , onClick (NavigateToRoute StatisticsRoute)
+                    ]
+                    [ text "完了" ]
+                ]
+
+        ModelInvalid _ ->
+            text "durationが存在していません。"
 
 
 {-| アップデート
 -}
-update : Nav.Key -> Msg -> Cmd Msg
-update key msg =
+update : Nav.Key -> Msg -> Model -> ( Model, Cmd Msg )
+update key msg model =
     case msg of
         NavigateToRoute route ->
-            Nav.pushUrl key (Route.toString route)
+            ( model, Nav.pushUrl key (Route.toString route) )

--- a/frontend/src/Pages/SessionPreparationPage.elm
+++ b/frontend/src/Pages/SessionPreparationPage.elm
@@ -39,15 +39,27 @@ import Browser.Navigation as Nav
 import Html exposing (Html, button, div, input, span, text)
 import Html.Attributes exposing (attribute, disabled, style)
 import Html.Events exposing (onClick, onInput)
+import List.Extra
+import RemoteData exposing (RemoteData(..))
 import Route exposing (Route(..))
-import Types.BreathingMethod exposing (BreathingMethod, fromExhaleDuration, fromExhaleHoldDuration, fromInhaleDuration, fromInhaleHoldDuration)
-import Types.Session exposing (Duration, toDuration)
+import Task
+import Time
+import Types.BreathingMethod exposing (BreathingMethod, BreathingMethodId, fromExhaleDuration, fromExhaleHoldDuration, fromInhaleDuration, fromInhaleHoldDuration)
+import Types.Session exposing (toDuration)
 
 
 {-| Model
 -}
-type alias Model =
-    { sessionDurationInput : String
+type Model
+    = ModelLoading PracticeStyle
+    | ModelLoaded InternalModel
+
+
+{-| 内部で利用されるModel
+-}
+type alias InternalModel =
+    { practiceStyle : ValidPracticeStyle
+    , sessionDurationInput : String
     , inhaleDurationInput : String
     , inhaleHoldDurationInput : String
     , exhaleDurationInput : String
@@ -55,11 +67,66 @@ type alias Model =
     }
 
 
+{-| 練習スタイルを検証する
+
+既存の呼吸法のリストに存在するかを検証する
+
+-}
+validatePracticeStyle : List BreathingMethod -> PracticeStyle -> Maybe ValidPracticeStyle
+validatePracticeStyle breathingMethods practiceStyle =
+    case practiceStyle of
+        ManualPracticeStyle ->
+            Just Manual
+
+        PresetPracticeStyle id ->
+            List.Extra.find (.id >> (==) id) breathingMethods
+                |> Maybe.map Preset
+
+
 {-| 初期化
 -}
-init : () -> Model
-init _ =
-    { sessionDurationInput = ""
+init : RemoteData e (List BreathingMethod) -> PracticeStyle -> ( Model, Cmd Msg )
+init remote practiceStyle =
+    case remote of
+        NotAsked ->
+            ( ModelLoading practiceStyle, Cmd.none )
+
+        Loading ->
+            ( ModelLoading practiceStyle, Cmd.none )
+
+        Failure _ ->
+            ( ModelLoading practiceStyle
+              -- ホーム画面へ遷移する - [ ] TODO: エラーメッセージを表示する
+            , NavigateToRoute HomeRoute
+                |> always
+                |> Task.perform
+                |> (|>) Time.now
+            )
+
+        Success breathingMethods ->
+            case validatePracticeStyle breathingMethods practiceStyle of
+                Just valid ->
+                    ( initInternal valid
+                        |> ModelLoaded
+                    , Cmd.none
+                    )
+
+                Nothing ->
+                    ( ModelLoading practiceStyle
+                      -- 存在しない呼吸法のため、ホーム画面へ遷移する - [ ] TODO: エラーメッセージを表示する
+                    , NavigateToRoute HomeRoute
+                        |> always
+                        |> Task.perform
+                        |> (|>) Time.now
+                    )
+
+
+{-| 内部で利用される初期化
+-}
+initInternal : ValidPracticeStyle -> InternalModel
+initInternal m =
+    { practiceStyle = m
+    , sessionDurationInput = ""
     , inhaleDurationInput = ""
     , inhaleHoldDurationInput = ""
     , exhaleDurationInput = ""
@@ -75,13 +142,56 @@ type Msg
     | InputInhaleHoldDuration String
     | InputExhaleDuration String
     | InputExhaleHoldDuration String
-    | PrepareSessionPageNavigateToRoute Route
+    | NavigateToRoute Route
 
 
 {-| アップデート
 -}
-update : Nav.Key -> Msg -> Model -> ( Model, Cmd Msg )
-update key msg model =
+update : RemoteData e (List BreathingMethod) -> Nav.Key -> Msg -> Model -> ( Model, Cmd Msg )
+update remote key msg model =
+    case model of
+        ModelLoading practiceStyle ->
+            case remote of
+                NotAsked ->
+                    ( model, Cmd.none )
+
+                Loading ->
+                    ( model, Cmd.none )
+
+                Failure _ ->
+                    ( model
+                      -- 失敗したのでホーム画面へ遷移する
+                    , NavigateToRoute HomeRoute
+                        |> always
+                        |> Task.perform
+                        |> (|>) Time.now
+                    )
+
+                Success breathingMethods ->
+                    case validatePracticeStyle breathingMethods practiceStyle of
+                        Just valid ->
+                            ( initInternal valid
+                                |> ModelLoaded
+                            , Cmd.none
+                            )
+
+                        Nothing ->
+                            ( model
+                            , NavigateToRoute HomeRoute
+                                |> always
+                                |> Task.perform
+                                |> (|>) Time.now
+                            )
+
+        ModelLoaded internalModel ->
+            updateInternal key msg internalModel
+                |> Tuple.mapFirst ModelLoaded
+
+
+{-| 内部で利用されるアップデート
+-}
+updateInternal : Nav.Key -> Msg -> InternalModel -> ( InternalModel, Cmd Msg )
+updateInternal key msg model =
     case msg of
         InputSessionDuration duration ->
             ( { model | sessionDurationInput = duration }, Cmd.none )
@@ -98,7 +208,7 @@ update key msg model =
         InputExhaleHoldDuration duration ->
             ( { model | exhaleHoldDurationInput = duration }, Cmd.none )
 
-        PrepareSessionPageNavigateToRoute route ->
+        NavigateToRoute route ->
             ( model, Nav.pushUrl key (Route.toString route) )
 
 
@@ -108,52 +218,77 @@ update key msg model =
 
 -}
 type PracticeStyle
+    = ManualPracticeStyle
+    | PresetPracticeStyle BreathingMethodId
+
+
+{-| 正常な練習スタイル
+-}
+type ValidPracticeStyle
     = Manual
     | Preset BreathingMethod
 
 
 {-| ビュー
 -}
-view : { a | txt : String, practiceStyle : PracticeStyle, route : Duration -> Route } -> Model -> Html Msg
-view { txt, practiceStyle, route } model =
-    let
-        breathingMethodControls =
-            case practiceStyle of
-                Manual ->
-                    BreathingMethodDurationInput.view
-                        (BreathingMethodDurationInput.Config
-                            InputInhaleDuration
-                            InputInhaleHoldDuration
-                            InputExhaleDuration
-                            InputExhaleHoldDuration
-                        )
-                        model
+view : { a | txt : String } -> Model -> Html Msg
+view { txt } model =
+    case model of
+        ModelLoaded loaded ->
+            let
+                breathingMethodControls =
+                    case loaded.practiceStyle of
+                        Manual ->
+                            BreathingMethodDurationInput.view
+                                (BreathingMethodDurationInput.Config
+                                    InputInhaleDuration
+                                    InputInhaleHoldDuration
+                                    InputExhaleDuration
+                                    InputExhaleHoldDuration
+                                )
+                                loaded
 
-                Preset m ->
-                    div []
-                        [ span [ attribute "aria-label" "inhale" ] [ text <| String.fromInt <| fromInhaleDuration m.inhaleDuration ]
-                        , span [ attribute "aria-label" "inhale-hold" ] [ text <| String.fromInt <| fromInhaleHoldDuration m.inhaleHoldDuration ]
-                        , span [ attribute "aria-label" "exhale" ] [ text <| String.fromInt <| fromExhaleDuration m.exhaleDuration ]
-                        , span [ attribute "aria-label" "exhale-hold" ] [ text <| String.fromInt <| fromExhaleHoldDuration m.exhaleHoldDuration ]
-                        ]
-    in
-    div [ attribute "role" "preparation" ]
-        [ text txt
-        , input
-            [ attribute "aria-label" "session-duration-input"
-            , onInput InputSessionDuration
-            ]
-            []
-        , breathingMethodControls
-        , button
-            [ attribute "aria-label" "start-session"
-            , case Maybe.andThen toDuration <| String.toInt model.sessionDurationInput of
-                Just duration ->
-                    onClick (PrepareSessionPageNavigateToRoute (route duration))
+                        Preset m ->
+                            div []
+                                [ span [ attribute "aria-label" "inhale" ] [ text <| String.fromInt <| fromInhaleDuration m.inhaleDuration ]
+                                , span [ attribute "aria-label" "inhale-hold" ] [ text <| String.fromInt <| fromInhaleHoldDuration m.inhaleHoldDuration ]
+                                , span [ attribute "aria-label" "exhale" ] [ text <| String.fromInt <| fromExhaleDuration m.exhaleDuration ]
+                                , span [ attribute "aria-label" "exhale-hold" ] [ text <| String.fromInt <| fromExhaleHoldDuration m.exhaleHoldDuration ]
+                                ]
 
-                Nothing ->
-                    disabled True
-            ]
-            [ text "セッション開始" ]
-        , div [ attribute "aria-label" "backdrop", style "width" "10px", style "height" "10px", style "background-color" "gray" ] []
-        ]
+                route duration =
+                    case loaded.practiceStyle of
+                        Manual ->
+                            ManualSessionRoute (Just duration)
+                                (Maybe.andThen Types.BreathingMethod.toInhaleDuration <| String.toInt loaded.inhaleDurationInput)
+                                (Maybe.andThen Types.BreathingMethod.toInhaleHoldDuration <| String.toInt loaded.inhaleHoldDurationInput)
+                                (Maybe.andThen Types.BreathingMethod.toExhaleDuration <| String.toInt loaded.exhaleDurationInput)
+                                (Maybe.andThen Types.BreathingMethod.toExhaleHoldDuration <| String.toInt loaded.exhaleHoldDurationInput)
+
+                        Preset method ->
+                            PresetSessionRoute method.id (Just duration)
+            in
+            div [ attribute "role" "preparation" ]
+                [ text txt
+                , input
+                    [ attribute "aria-label" "session-duration-input"
+                    , onInput InputSessionDuration
+                    ]
+                    []
+                , breathingMethodControls
+                , button
+                    [ attribute "aria-label" "start-session"
+                    , case Maybe.andThen toDuration <| String.toInt loaded.sessionDurationInput of
+                        Just duration ->
+                            onClick (NavigateToRoute (route duration))
+
+                        Nothing ->
+                            disabled True
+                    ]
+                    [ text "セッション開始" ]
+                , div [ attribute "aria-label" "backdrop", style "width" "10px", style "height" "10px", style "background-color" "gray" ] []
+                ]
+
+        ModelLoading _ ->
+            div []
+                [ text "Loading..." ]

--- a/frontend/src/RemoteData.elm
+++ b/frontend/src/RemoteData.elm
@@ -1,6 +1,6 @@
 module RemoteData exposing
     ( RemoteData(..)
-    , fromResult
+    , fromResult, map
     )
 
 {-|
@@ -18,7 +18,7 @@ module RemoteData exposing
 
 ### ヘルパー
 
-@docs fromResult
+@docs fromResult, map
 
 -}
 
@@ -42,3 +42,21 @@ fromResult result =
 
         Ok a ->
             Success a
+
+
+{-| map関数
+-}
+map : (a -> b) -> RemoteData e a -> RemoteData e b
+map f remoteData =
+    case remoteData of
+        NotAsked ->
+            NotAsked
+
+        Loading ->
+            Loading
+
+        Failure e ->
+            Failure e
+
+        Success a ->
+            Success (f a)


### PR DESCRIPTION
ページ内のロジックであるはずのリダイレクト処理を、すべて適正な位置に戻しました。例えばBreathingMethodたちがローディング中か否かをMain.elmのModelで保持し、ページ内で適切なタイミングでリダイレクト処理を行うように修正しました。